### PR TITLE
Update versions, include andyshinn/dnsmasq & copy tripox/dory-dnsmasq PR

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+tag=2.89.6
+alpine_tag=3.19
+dnsmasq_version=2.89-r6
+platforms=linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM andyshinn/dnsmasq:2.75
+ARG alpine_tag
+
+FROM alpine:${alpine_tag}
+
+ARG dnsmasq_version
+RUN apk --no-cache add dnsmasq-dnssec=${dnsmasq_version}
+EXPOSE 53 53/udp
 
 COPY dnsmasq.conf /etc/dnsmasq.conf
 COPY start-with-domain-ip.sh /usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+include .env
+
+default: help
+
+## help		:	Prints this help.
+.PHONY: help
+help :
+	@sed -n 's/^##//p' Makefile
+
+## builder	:	Create the builder.
+.PHONY: builder
+builder :
+	docker buildx create --name dory --use
+
+## build push	:	Build and push docker images.
+.PHONY: build push
+build push :
+	docker buildx build --build-arg alpine_tag=${alpine_tag} --build-arg dnsmasq_version=${dnsmasq_version} --platform ${platforms} -t docker.io/tripox/dory-dnsmasq:${tag} . --push
+	docker buildx build --build-arg alpine_tag=${alpine_tag} --build-arg dnsmasq_version=${dnsmasq_version} --platform ${platforms} -t docker.io/tripox/dory-dnsmasq:latest . --push
+
+## remove		:	Remove the builder.
+.PHONY: remove
+remove :
+	docker buildx rm dory

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [Dory](https://github.com/FreedomBen/dory) uses this container to provide the dnsmasq
 services in conjunction with an nginx-proxy.  It's a very lightweight container built
-on Alpine Linux (based off of [andyshinn/dnsmasq](https://hub.docker.com/r/andyshinn/dnsmasq/).
+on Alpine Linux, using only the dnsmasq-dnssec package.
 See the [dory](https://github.com/FreedomBen/dory) project page for more info.
 
 ## How do I use it?
@@ -62,3 +62,28 @@ docker run -p 53:53/tcp -p 53:53/udp --cap-add=NET_ADMIN freedomben/dory-dnsmasq
 ```
 
 *NOTE:  You have to put the # in quotes otherwise bash will think it's a comment character*
+
+### Build and push images
+
+Create the builder:
+
+```bash
+make builder
+```
+
+Build and push images:
+
+```bash
+make build push
+```
+
+Remove the builder:
+
+```bash
+make remove
+```
+
+### Credit
+
+- A lightweight docker image for dnsmasq [andyshinn/dnsmasq](https://hub.docker.com/r/andyshinn/dnsmasq/).
+- A PR to add compatibility for Mac M-series chips [tripox/dory-dnsmasq](https://github.com/tripox/dory-dnsmasq/commit/72549c39324014c5092cb8103378d58fbf51df80).


### PR DESCRIPTION
This PR includes the work done here https://github.com/FreedomBen/dory-dnsmasq/pull/2 - it includes Mac M-series support and a makerfile.

It also used the lates alpine release, and installs dnsmasq-dnssec within the Dockerfile, to reduce the external and outdated dependency on andyshinn/dnsmasq.

Below is a screenshot of the current vulnerabilities, the image resulting rom this PR has 0 known vulnerabilities when pushed and scanned on docker hub.

![Screenshot of vulnerabilities.](https://private-user-images.githubusercontent.com/47327051/300449414-d3adb79f-d737-4ae5-87af-6e49b9565089.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDY1MzQxODgsIm5iZiI6MTcwNjUzMzg4OCwicGF0aCI6Ii80NzMyNzA1MS8zMDA0NDk0MTQtZDNhZGI3OWYtZDczNy00YWU1LTg3YWYtNmU0OWI5NTY1MDg5LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDAxMjklMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwMTI5VDEzMTEyOFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWM0YjY2ZWJhOGU5OTFjMTc0NDU0OGViOWVhZjA3NzExODBmY2FmZTVkMmRiZDFhZjBhNGFiMGU2NGUzNzU5MDYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.DEU1K_U5GcGs5UgJShJWze0JAOj-KSfZL_cRSXwU1FQ)